### PR TITLE
Fix release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 MANIFEST
 dist/
 .idea/
+build

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LONG_DESCRIPTION.rst

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,17 @@
 from distutils.core import setup
+from os import path
 
-with open('LONG_DESCRIPTION.rst') as fid:
-  long = fid.read()
+here = path.abspath(path.dirname(__file__))
+
+with open(path.join(here, 'LONG_DESCRIPTION.rst')) as fid:
+  long_desc = fid.read()
 
 setup(
   name='python_purify',
   packages=['python_purify'],
   version='1.0.1',
   description='A python API for Web Purify',
-  long_description=long,
+  long_description=long_desc,
   author='Tom King, Kory Donati',
   author_email=['tomk@bixly.com', 'koryd@bixly.com'],
   url='https://github.com/kingthomasc/python-purify',


### PR DESCRIPTION
Trying to install with pip produces the error:

```
$ pip install python_purify
Collecting python-purify
  Using cached python_purify-1.0.1.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/zq/73nnxbc119gbm6xbvxfhrypm0000gn/T/pip-build-dXQ8R3/python-purify/setup.py", line 3, in <module>
        with open('LONG_DESCRIPTION.rst') as fid:
    IOError: [Errno 2] No such file or directory: 'LONG_DESCRIPTION.rst'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/zq/73nnxbc119gbm6xbvxfhrypm0000gn/T/pip-build-dXQ8R3/python-purify
```

So I fixed the packing by including `LONG_DESCRIPTION.rst` in `MANIFEST.in`. I also added a safety net to use the absolute path to the file based on the location of `setup.py` and changed `long` to `long_desc` because `long` is a type in Python and overriding builtins isn't a good practice.

I published my changes to testpypi under python_purify_fork2 and installing now works as expected:

```
$ pip install -i https://testpypi.python.org/pypi python_purify_fork2
Collecting python-purify-fork2
  Downloading https://testpypi.python.org/packages/source/p/python_purify_fork2/python_purify_fork2-1.0.3.tar.gz
Building wheels for collected packages: python-purify-fork2
  Running setup.py bdist_wheel for python-purify-fork2 ... done
  Stored in directory: /Users/lee/Library/Caches/pip/wheels/e1/6d/dc/7dcb3ae6a7a3a46bc664801c41c190feef3e6afb9380ce0ec1
Successfully built python-purify-fork2
Installing collected packages: python-purify-fork2
Successfully installed python-purify-fork2-1.0.3
```
